### PR TITLE
Use account-daemon interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -217,7 +217,7 @@ apps:
       - dbus-colord
 
     plugs: &pluglist
-      - account-control
+      - account-daemon
       - audio-playback
       - audio-record
       - avahi-control


### PR DESCRIPTION
The account-daemon interface is designed for a snapped account daemon, so it must be changed.

This is a draft because it must be merged in upstream; but since it depends on `stand-alone-ubuntu-session`, this allows to see the specific changes.